### PR TITLE
Refactor: Import MySQL config from db_config.py and remove the configuration from code

### DIFF
--- a/src/birdnet_pi_realtime.py
+++ b/src/birdnet_pi_realtime.py
@@ -12,6 +12,7 @@ import csv
 from scipy.signal import resample
 import mariadb
 import syslog
+
 from db_config import MYSQL_CONFIG
 
 # ================================

--- a/src/birdnet_pi_realtime.py
+++ b/src/birdnet_pi_realtime.py
@@ -12,6 +12,7 @@ import csv
 from scipy.signal import resample
 import mariadb
 import syslog
+from db_config import MYSQL_CONFIG
 
 # ================================
 # CONFIGURATION
@@ -28,13 +29,6 @@ CSV_LOG = "detections.csv"
 DEBUG_AUDIO_DIR = "/mnt/ramdisk/debug_audio"
 RAMDISK_WARNING_THRESHOLD_MB = 100
 
-MYSQL_CONFIG = {
-    'host': '',
-    'user': '',
-    'password': '',
-    'database': '',
-    'port': 3307
-}
 
 os.makedirs(DEBUG_AUDIO_DIR, exist_ok=True)
 write_header = not os.path.exists(CSV_LOG)


### PR DESCRIPTION
### Summary
This PR extracts the 'MYSQL_CONFIG' dictionary from 'birdnet_pi_realtime.py' into a new 'db_config.py' module.  This improves separation of concerns and makes it easier to manage credentials and environment-specific configurations in the future.

### Why
- reduced hardcoing of sensitive settings
- prepares the app for future '.env' or secret manager support for these parameters
- simplifies testing and reuse of config data

### Changes
- Created 'db_config.pu' with the 'MYSQL_CONFIG' dictionary
- updated 'birdnet_pi_realtime.py' to import the config, and removed the old config from code